### PR TITLE
Fix cep with spaces

### DIFF
--- a/Consulta de endereço pelo CEP.py
+++ b/Consulta de endereço pelo CEP.py
@@ -8,7 +8,7 @@ print('\nBem-vindo ao sistema de consulta de CEP.')
 
 def cep():
     cep_int = input('Por favor, digite o CEP que você gostaria de procurar na base (ex: 00000000): ')
-    responde = requests.get('https://viacep.com.br/ws/' + cep_int + '/json/')
+    responde = requests.get('https://viacep.com.br/ws/' + cep_int.strip() + '/json/')
     # Verifica se a requisiçao HTTP está disponível.
     if responde.status_code != 200:
         print('Não foi possível acessar o CEP por favor verifique seu número e digite novamente.')


### PR DESCRIPTION
When we add spaces in the end of the cep, the viacep api doesn't understand it as a valid one. Because of that we need to make sure that we remove spaces before make the request. 

In the image below we see what happened with the same cep without and with spaces. 
![](https://i.imgur.com/nNbtLT3.png)