### PR TITLE
Remove unnecessary function

### DIFF
--- a/Consulta de endereço pelo CEP.py
+++ b/Consulta de endereço pelo CEP.py
@@ -5,20 +5,11 @@
 import requests
 print('\nBem-vindo ao sistema de consulta de CEP.')
 
-
-def verifyJson(response: str):
-    try:
-        if response['erro'] == True:
-            return False
-        return True
-    except KeyError: ## True = Sem erros no json | False = Json com problema
-        return True
-
 def cep():
     cep_int = input('Por favor, digite o CEP que você gostaria de procurar na base (ex: 00000000): ')
     responde = requests.get(f'https://viacep.com.br/ws/{cep_int.strip()}/json/')
     # Verifica se a requisiçao HTTP está disponível.
-    if responde.status_code != 200 or verifyJson(responde.json()) == False:
+    if responde.status_code != 200 or responde.json().get('erro'):
         print('\033[31mNão foi possível acessar o CEP por favor verifique seu número e digite novamente.\033[0;0m')
     else:
         # Armazena o dicionario em uma variável


### PR DESCRIPTION
When dealing with python dictionaries, there's a very common exception, the `KeyError`, that raises when a given key is not found in the dict.

I noticed that when trying to fix an issue that occurred when the API returned an error, a function `verifyJson` was created.
Basically, that function executed a `try catch` block, that checked for such exception (`KeyError`)

However, there's a simpler way to deal with that.
Python dictionaries have a method called `get(key, value)` that basically checks if the dict has the given `key`, returns `value` if the key is not found and `dict['key']` if it is. (`value` defaults to `None`)

Therefore, since `None` is a falsy value, that get's evaluated to `False` in a logical expression so, the following statements mean the same:

`if responde.status_code != 200 or verifyJson(responde.json()) == False:`
`if responde.status_code != 200 or responde.json().get('erro'):`

or even:

`if responde.status_code != 200 or responde.json().get('erro', False):`

To see more information about `dict.get()` method, check this [W3S reference page](https://www.w3schools.com/python/ref_dictionary_get.asp)